### PR TITLE
Add support for field name that ends with '_id'

### DIFF
--- a/test/api_test.py
+++ b/test/api_test.py
@@ -21,6 +21,7 @@ class MyTinyModel(TinyModel):
         FieldDef('my_default_value', allowed_types=[bool], default=__default),
         FieldDef('my_datetime', allowed_types=[datetime]),
         FieldDef('my_float', allowed_types=[float]),
+        FieldDef('my_id', allowed_types=[str, unicode]),
     ]
 
 
@@ -35,7 +36,7 @@ class MyForeignModel(object):
 
 class APiTest(TestCase):
     TEST_DEFAULT_PARAMS = {'my_str': 'str', 'my_int': 1, 'my_bool': True, 'my_default_value': False}
-    VALID_PARAMS = {'my_str': 'str', 'my_int': 1, 'my_bool': True, }
+    VALID_PARAMS = {'my_str': 'str', 'my_int': 1, 'my_bool': True, 'my_id': 'TEST'}
     INVALID_PARAMS = {'my_str': 1, 'my_fk': MyForeignModel(), 'my_fk_id': 'foo',
                       'my_m2m': [MyForeignModel()], 'my_m2m_ids': ['foo', u'bar'],
                       'foo': 'foo'}

--- a/tinymodel/internals/validation.py
+++ b/tinymodel/internals/validation.py
@@ -138,7 +138,12 @@ def __match_field_value(cls, name, value):
                         if not valid:
                             raise ValidationError(error.format(value, name, field_def.allowed_types))
     else:
-        if name.endswith('_id'):
+        try:
+            field_def = filter(lambda f: f.title == name, cls.FIELD_DEFS)[0]
+        except IndexError:  # the id is expanded with _id, remove _id
+            field_def = filter(lambda f: f.title == name[:-3], cls.FIELD_DEFS)[0]
+
+        if name.endswith('_id') and field_def.relationship != 'attribute':
             if value_type not in (long, int, str, unicode):
                 raise ValidationError(error.format(value, name, [long, int, str, unicode]))
             if value_type in (str, unicode):


### PR DESCRIPTION
TinyModel field names ended with '_id' break `__match_field_value` due to we are making assumptions that every field ended with `_id` should be a `has_one` relationship.
